### PR TITLE
Simplify the container

### DIFF
--- a/.tekton/konflux-rpm-prefetch-sources-pull-request.yaml
+++ b/.tekton/konflux-rpm-prefetch-sources-pull-request.yaml
@@ -11,11 +11,11 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: konflux-rpm-prefetch-sources
-    appstudio.openshift.io/component: konflux-rpm-prefetch-sources
+    appstudio.openshift.io/application: fedora-on-konflux
+    appstudio.openshift.io/component: get-rpm-sources-container
     pipelines.appstudio.openshift.io/type: build
-  name: konflux-rpm-prefetch-sources-on-pull-request
-  namespace: rhn-support-praiskup-tenant
+  name: get-rpm-sources-container-on-pull-request
+  namespace: praiskup-redhat-com-tenant
 spec:
   params:
   - name: dockerfile
@@ -25,7 +25,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhn-support-praiskup-tenant/konflux-rpm-prefetch-sources/konflux-rpm-prefetch-sources:on-pr-{{revision}}
+    value: quay.io/konflux-fedora/praiskup-redhat-com-tenant/get-rpm-sources-container:on-pr-{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/konflux-rpm-prefetch-sources-push.yaml
+++ b/.tekton/konflux-rpm-prefetch-sources-push.yaml
@@ -10,11 +10,11 @@ metadata:
       == "main"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: konflux-rpm-prefetch-sources
-    appstudio.openshift.io/component: konflux-rpm-prefetch-sources
+    appstudio.openshift.io/application: fedora-on-konflux
+    appstudio.openshift.io/component: get-rpm-sources-container
     pipelines.appstudio.openshift.io/type: build
-  name: konflux-rpm-prefetch-sources-on-push
-  namespace: rhn-support-praiskup-tenant
+  name: get-rpm-sources-container-on-pull-push
+  namespace: praiskup-redhat-com-tenant
 spec:
   params:
   - name: dockerfile
@@ -22,7 +22,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/rhn-support-praiskup-tenant/konflux-rpm-prefetch-sources/konflux-rpm-prefetch-sources:{{revision}}
+    value: quay.io/konflux-fedora/praiskup-redhat-com-tenant/get-rpm-sources-container:{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/Containerfile
+++ b/Containerfile
@@ -3,9 +3,5 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
-    && dnf -y install copr-distgit-client python3-six && \
+    && dnf -y install dist-git-client && \
     dnf clean all
-
-COPY ./konflux-fedora-rpms.ini /etc/copr-distgit-client/
-
-RUN chmod 0644 /etc/copr-distgit-client/konflux-fedora-rpms.ini

--- a/konflux-fedora-rpms.ini
+++ b/konflux-fedora-rpms.ini
@@ -1,6 +1,0 @@
-[konflux-fedora-rpms]
-clone_hostnames = github.com
-path_prefixes = /konflux-fedora-rpm-packages
-lookaside_location = https://src.fedoraproject.org
-lookaside_uri_pattern = repo/pkgs/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}
-cloning_pattern = https://github.com/konflux-fedora-rpm-packages/{package}.git


### PR DESCRIPTION
- we don't need the copr-* package, there's a distribution/build-system agnostic package dist-git-client now
- no need to add additional configuration for dist-git-client, because we don't want to force the user to host the source codes in standardized location (the konflux-fedora-rpm-packages group); eventually it seems better to use the dist-git-client --forked-from option explicitly